### PR TITLE
Add dashboard demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Dashboard Demo
+
+The application now includes a very small dashboard similar to the layout on
+[yodeck.com](https://www.yodeck.com). Click **Open Dashboard** on the home page
+to view a list of example sections (Screens, Playlists, Schedules and Settings).
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/App.js
+++ b/src/App.js
@@ -1,22 +1,21 @@
+import React, { useState } from 'react';
 import logo from './logo.svg';
 import './App.css';
+import Dashboard from './Dashboard';
 
 function App() {
+  const [page, setPage] = useState('home');
+
+  if (page === 'dashboard') {
+    return <Dashboard onBack={() => setPage('home')} />;
+  }
+
   return (
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
+        <p>Welcome to Vypa.</p>
+        <button onClick={() => setPage('dashboard')}>Open Dashboard</button>
       </header>
     </div>
   );

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders dashboard button', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const button = screen.getByText(/open dashboard/i);
+  expect(button).toBeInTheDocument();
 });

--- a/src/Dashboard.css
+++ b/src/Dashboard.css
@@ -1,0 +1,15 @@
+.Dashboard {
+  padding: 2rem;
+}
+
+.Dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.Dashboard-back {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}

--- a/src/Dashboard.js
+++ b/src/Dashboard.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import './Dashboard.css';
+
+function Dashboard({ onBack }) {
+  return (
+    <div className="Dashboard">
+      <header className="Dashboard-header">
+        <h1>Vypa Dashboard</h1>
+        {onBack && (
+          <button className="Dashboard-back" onClick={onBack}>
+            Back
+          </button>
+        )}
+      </header>
+      <p>This is a simple dashboard placeholder similar to Yodeck.</p>
+      <ul>
+        <li>Screens</li>
+        <li>Playlists</li>
+        <li>Schedules</li>
+        <li>Settings</li>
+      </ul>
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/src/Dashboard.test.js
+++ b/src/Dashboard.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import Dashboard from './Dashboard';
+
+test('renders dashboard title', () => {
+  render(<Dashboard />);
+  const title = screen.getByText(/Vypa Dashboard/i);
+  expect(title).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add a minimal Dashboard component
- link dashboard from App and update test
- document the demo in README

## Testing
- `node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false --runTestsByPath src/App.test.js src/Dashboard.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684d5a0346e8832bbc35111f8467a04b